### PR TITLE
Handle PLI

### DIFF
--- a/track.go
+++ b/track.go
@@ -136,67 +136,40 @@ func (t *publisherTrack) handleSample(sink *app.Sink) gst.FlowReturn {
 }
 
 func (t *publisherTrack) onRTCP(packet rtcp.Packet) {
-	switch p := packet.(type) {
-	case *rtcp.PictureLossIndication:
-		logger.Infow("received PLI", "mimeType", t.mimeType, "senderSSRC", p.SenderSSRC, "mediaSSRC", p.MediaSSRC)
-		t.forceKeyframe("PLI")
-	case *rtcp.FullIntraRequest:
-		logger.Infow("received FIR", "mimeType", t.mimeType, "senderSSRC", p.SenderSSRC, "mediaSSRC", p.MediaSSRC)
-		t.forceKeyframe("FIR")
-	default:
-		logger.Debugw("received RTCP packet", "mimeType", t.mimeType, "type", fmt.Sprintf("%T", packet))
+	switch packet.(type) {
+	case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest:
+		t.forceKeyframe()
 	}
 }
 
-func (t *publisherTrack) forceKeyframe(reason string) {
+func (t *publisherTrack) forceKeyframe() {
 	if t.mimeType == webrtc.MimeTypeOpus {
-		logger.Debugw("ignoring keyframe request on audio track", "reason", reason)
 		return
 	}
 
 	now := time.Now().UnixNano()
 	last := t.lastKeyframeRequestNs.Load()
 	if now-last < int64(minKeyframeRequestInterval) {
-		logger.Infow("debouncing keyframe request",
-			"reason", reason,
-			"sinceLastMs", (now-last)/int64(time.Millisecond),
-			"minIntervalMs", int64(minKeyframeRequestInterval/time.Millisecond))
 		return
 	}
 	if !t.lastKeyframeRequestNs.CompareAndSwap(last, now) {
-		logger.Debugw("another goroutine is handling keyframe request", "reason", reason)
 		return
 	}
 
 	s := gst.NewStructure("GstForceKeyUnit")
-	if err := s.SetValue("all-headers", true); err != nil {
-		logger.Warnw("failed to set all-headers on force-keyframe event", err)
-	}
+	_ = s.SetValue("all-headers", true)
 	ev := gst.NewCustomEvent(gst.EventTypeCustomUpstream, s)
 
 	pad := t.sink.GetStaticPad("sink")
 	if pad == nil {
-		logger.Warnw("appsink has no sink pad", nil, "reason", reason)
 		return
 	}
 
-	peer := pad.GetPeer()
-	peerName := "<unlinked>"
-	if peer != nil {
-		if peerParent := peer.GetParentElement(); peerParent != nil {
-			peerName = peerParent.GetName()
-		}
+	// PushEvent forwards the event to the pad's peer. For the appsink's sink
+	// pad, the peer is the src pad of the upstream element, so the upstream
+	// force-key-unit event travels upstream toward the encoder. SendEvent
+	// would be rejected by GStreamer as "wrong direction" on a sink pad.
+	if ok := pad.PushEvent(ev); !ok {
+		logger.Warnw("force-keyframe event was not handled by pipeline", nil)
 	}
-
-	// PushEvent forwards the event to the pad's peer. For the appsink's sink pad,
-	// the peer is the src pad of the upstream element, so the upstream
-	// force-key-unit event travels upstream toward the encoder. Using
-	// gst_pad_send_event (our previous approach) is rejected by GStreamer as
-	// "wrong direction" for a sink pad + upstream event.
-	ok := pad.PushEvent(ev)
-	logger.Infow("pushed force-keyframe event upstream",
-		"reason", reason,
-		"mimeType", t.mimeType,
-		"peer", peerName,
-		"handled", ok)
 }

--- a/track.go
+++ b/track.go
@@ -136,36 +136,67 @@ func (t *publisherTrack) handleSample(sink *app.Sink) gst.FlowReturn {
 }
 
 func (t *publisherTrack) onRTCP(packet rtcp.Packet) {
-	switch packet.(type) {
-	case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest:
-		t.forceKeyframe()
+	switch p := packet.(type) {
+	case *rtcp.PictureLossIndication:
+		logger.Infow("received PLI", "mimeType", t.mimeType, "senderSSRC", p.SenderSSRC, "mediaSSRC", p.MediaSSRC)
+		t.forceKeyframe("PLI")
+	case *rtcp.FullIntraRequest:
+		logger.Infow("received FIR", "mimeType", t.mimeType, "senderSSRC", p.SenderSSRC, "mediaSSRC", p.MediaSSRC)
+		t.forceKeyframe("FIR")
+	default:
+		logger.Debugw("received RTCP packet", "mimeType", t.mimeType, "type", fmt.Sprintf("%T", packet))
 	}
 }
 
-func (t *publisherTrack) forceKeyframe() {
+func (t *publisherTrack) forceKeyframe(reason string) {
 	if t.mimeType == webrtc.MimeTypeOpus {
+		logger.Debugw("ignoring keyframe request on audio track", "reason", reason)
 		return
 	}
 
 	now := time.Now().UnixNano()
 	last := t.lastKeyframeRequestNs.Load()
 	if now-last < int64(minKeyframeRequestInterval) {
+		logger.Infow("debouncing keyframe request",
+			"reason", reason,
+			"sinceLastMs", (now-last)/int64(time.Millisecond),
+			"minIntervalMs", int64(minKeyframeRequestInterval/time.Millisecond))
 		return
 	}
 	if !t.lastKeyframeRequestNs.CompareAndSwap(last, now) {
+		logger.Debugw("another goroutine is handling keyframe request", "reason", reason)
 		return
 	}
 
 	s := gst.NewStructure("GstForceKeyUnit")
 	if err := s.SetValue("all-headers", true); err != nil {
-		logger.Debugw("failed to set all-headers on force-keyframe event", "error", err)
+		logger.Warnw("failed to set all-headers on force-keyframe event", err)
 	}
 	ev := gst.NewCustomEvent(gst.EventTypeCustomUpstream, s)
+
 	pad := t.sink.GetStaticPad("sink")
 	if pad == nil {
+		logger.Warnw("appsink has no sink pad", nil, "reason", reason)
 		return
 	}
-	if ok := pad.SendEvent(ev); !ok {
-		logger.Debugw("force-keyframe event was not handled by pipeline")
+
+	peer := pad.GetPeer()
+	peerName := "<unlinked>"
+	if peer != nil {
+		if peerParent := peer.GetParentElement(); peerParent != nil {
+			peerName = peerParent.GetName()
+		}
 	}
+
+	// PushEvent forwards the event to the pad's peer. For the appsink's sink pad,
+	// the peer is the src pad of the upstream element, so the upstream
+	// force-key-unit event travels upstream toward the encoder. Using
+	// gst_pad_send_event (our previous approach) is rejected by GStreamer as
+	// "wrong direction" for a sink pad + upstream event.
+	ok := pad.PushEvent(ev)
+	logger.Infow("pushed force-keyframe event upstream",
+		"reason", reason,
+		"mimeType", t.mimeType,
+		"peer", peerName,
+		"handled", ok)
 }

--- a/track.go
+++ b/track.go
@@ -27,16 +27,20 @@ import (
 	"github.com/pion/webrtc/v4"
 	"github.com/pion/webrtc/v4/pkg/media"
 
+	"github.com/livekit/protocol/logger"
 	lksdk "github.com/livekit/server-sdk-go/v2"
 )
 
+const minKeyframeRequestInterval = 500 * time.Millisecond
+
 type publisherTrack struct {
-	track       *lksdk.LocalTrack
-	sink        *app.Sink
-	mimeType    string
-	publication *lksdk.LocalTrackPublication
-	isEnded     atomic.Bool
-	onEOS       func()
+	track                 *lksdk.LocalTrack
+	sink                  *app.Sink
+	mimeType              string
+	publication           *lksdk.LocalTrackPublication
+	isEnded               atomic.Bool
+	onEOS                 func()
+	lastKeyframeRequestNs atomic.Int64
 }
 
 func createPublisherTrack(mimeType string) (*publisherTrack, error) {
@@ -132,5 +136,36 @@ func (t *publisherTrack) handleSample(sink *app.Sink) gst.FlowReturn {
 }
 
 func (t *publisherTrack) onRTCP(packet rtcp.Packet) {
-	// TODO: handle PLI by instructing the encoder to send a keyframe
+	switch packet.(type) {
+	case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest:
+		t.forceKeyframe()
+	}
+}
+
+func (t *publisherTrack) forceKeyframe() {
+	if t.mimeType == webrtc.MimeTypeOpus {
+		return
+	}
+
+	now := time.Now().UnixNano()
+	last := t.lastKeyframeRequestNs.Load()
+	if now-last < int64(minKeyframeRequestInterval) {
+		return
+	}
+	if !t.lastKeyframeRequestNs.CompareAndSwap(last, now) {
+		return
+	}
+
+	s := gst.NewStructure("GstForceKeyUnit")
+	if err := s.SetValue("all-headers", true); err != nil {
+		logger.Debugw("failed to set all-headers on force-keyframe event", "error", err)
+	}
+	ev := gst.NewCustomEvent(gst.EventTypeCustomUpstream, s)
+	pad := t.sink.GetStaticPad("sink")
+	if pad == nil {
+		return
+	}
+	if ok := pad.SendEvent(ev); !ok {
+		logger.Debugw("force-keyframe event was not handled by pipeline")
+	}
 }


### PR DESCRIPTION
This PR replaces a TODO comment with a full implementation of keyframe request handling. When a PictureLossIndication or FullIntraRequest RTCP packet is received, the publisher track now sends a GstForceKeyUnit upstream event through the GStreamer pipeline to the encoder.

Requests are rate-limited to at most one every 500ms using an atomic CAS on lastKeyframeRequestNs, and audio tracks (Opus) are skipped entirely.