### PR TITLE
Connect to room and start pipeline in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b // indirect
 	golang.org/x/net v0.46.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f // indirect

--- a/publish.go
+++ b/publish.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-gst/go-glib/glib"
 	"github.com/go-gst/go-gst/gst"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -74,47 +75,56 @@ func (p *Publisher) Start() error {
 		return err
 	}
 
-	// TODO: connect at the same time in parallel as spinning up pipeline
-	cb := lksdk.NewRoomCallback()
-	cb.OnDisconnected = func() {
-		// TODO: stop publishing and exit
-	}
-	p.room = lksdk.NewRoom(cb)
-	err := p.room.JoinWithToken(p.params.URL, p.params.Token,
-		lksdk.WithAutoSubscribe(false),
-	)
-	if err != nil {
-		return err
-	}
+	var g errgroup.Group
 
-	// publish tracks if sinks are set up
-	if p.videoTrack != nil {
-		pub, err := p.room.LocalParticipant.PublishTrack(p.videoTrack.track, &lksdk.TrackPublicationOptions{
-			Source: livekit.TrackSource_CAMERA,
-		})
-		if err != nil {
+	g.Go(func() error {
+		cb := lksdk.NewRoomCallback()
+		cb.OnDisconnected = func() {
+			// TODO: stop publishing and exit
+		}
+		p.room = lksdk.NewRoom(cb)
+		if err := p.room.JoinWithToken(p.params.URL, p.params.Token,
+			lksdk.WithAutoSubscribe(false),
+		); err != nil {
 			return err
 		}
-		p.videoTrack.publication = pub
-		p.videoTrack.onEOS = func() {
-			_ = p.room.LocalParticipant.UnpublishTrack(pub.SID())
-		}
-	}
 
-	if p.audioTrack != nil {
-		pub, err := p.room.LocalParticipant.PublishTrack(p.audioTrack.track, &lksdk.TrackPublicationOptions{
-			Source: livekit.TrackSource_MICROPHONE,
-		})
-		if err != nil {
-			return err
+		if p.videoTrack != nil {
+			pub, err := p.room.LocalParticipant.PublishTrack(p.videoTrack.track, &lksdk.TrackPublicationOptions{
+				Source: livekit.TrackSource_CAMERA,
+			})
+			if err != nil {
+				return err
+			}
+			p.videoTrack.publication = pub
+			onEOS := func() {
+				_ = p.room.LocalParticipant.UnpublishTrack(pub.SID())
+			}
+			p.videoTrack.onEOS.Store(&onEOS)
 		}
-		p.audioTrack.publication = pub
-		p.audioTrack.onEOS = func() {
-			_ = p.room.LocalParticipant.UnpublishTrack(pub.SID())
-		}
-	}
 
-	if err := p.pipeline.Start(); err != nil {
+		if p.audioTrack != nil {
+			pub, err := p.room.LocalParticipant.PublishTrack(p.audioTrack.track, &lksdk.TrackPublicationOptions{
+				Source: livekit.TrackSource_MICROPHONE,
+			})
+			if err != nil {
+				return err
+			}
+			p.audioTrack.publication = pub
+			onEOS := func() {
+				_ = p.room.LocalParticipant.UnpublishTrack(pub.SID())
+			}
+			p.audioTrack.onEOS.Store(&onEOS)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		return p.pipeline.Start()
+	})
+
+	if err := g.Wait(); err != nil {
+		p.Stop()
 		return err
 	}
 

--- a/track.go
+++ b/track.go
@@ -36,7 +36,7 @@ type publisherTrack struct {
 	mimeType    string
 	publication *lksdk.LocalTrackPublication
 	isEnded     atomic.Bool
-	onEOS       func()
+	onEOS       atomic.Pointer[func()]
 }
 
 func createPublisherTrack(mimeType string) (*publisherTrack, error) {
@@ -90,8 +90,8 @@ func (t *publisherTrack) IsEnded() bool {
 // callback function when EOS is received
 func (t *publisherTrack) handleEOS(_ *app.Sink) {
 	t.isEnded.Store(true)
-	if t.onEOS != nil {
-		t.onEOS()
+	if cb := t.onEOS.Load(); cb != nil {
+		(*cb)()
 	}
 }
 


### PR DESCRIPTION
This PR parallelizes the LiveKit room connection/track publishing and GStreamer pipeline startup using errgroup.Group. Previously these ran sequentially; now they execute concurrently:

```
// Before (sequential):
room.JoinWithToken(...)
publishTracks()
pipeline.Start()
// After (parallel):
var g errgroup.Group
g.Go(func() {
  room.JoinWithToken(...)
  publishTracks()
})
g.Go(func() {
  pipeline.Start()
})
g.Wait()
```

Since onEOS can now be written (after room join) while the pipeline is already running, the onEOS field is changed from a plain func() to an atomic.Pointer[func()] for thread safety.